### PR TITLE
Unify definitions

### DIFF
--- a/DataProducts/draft/Energy/Battery/ChargingHistory.json
+++ b/DataProducts/draft/Energy/Battery/ChargingHistory.json
@@ -124,7 +124,7 @@
             "title": "Serial Number",
             "type": "string",
             "description": "The serial number of the battery",
-            "example": "A080721"
+            "example": "MPP48V-296cde7f"
           },
           "start": {
             "title": "Start Time",

--- a/DataProducts/draft/Product/Manufacturing/EnvironmentalFootprint.json
+++ b/DataProducts/draft/Product/Manufacturing/EnvironmentalFootprint.json
@@ -85,13 +85,13 @@
     "schemas": {
       "EnvironmentalFootprintRequest": {
         "title": "EnvironmentalFootprintRequest",
-        "required": ["productId"],
+        "required": ["serialNumber"],
         "type": "object",
         "properties": {
-          "productId": {
-            "title": "Product ID",
+          "serialNumber": {
+            "title": "Serial Number",
             "type": "string",
-            "description": "The product ID given by the manufacturer",
+            "description": "The serial number given by the manufacturer",
             "example": "MPP48V-296cde7f"
           }
         }

--- a/DataProducts/draft/Product/Manufacturing/EnvironmentalFootprint.json
+++ b/DataProducts/draft/Product/Manufacturing/EnvironmentalFootprint.json
@@ -105,13 +105,13 @@
             "title": "Carbon Equivalent (CO2e) [kg]",
             "type": "number",
             "description": "The amount of emissions from all greenhouse gases converted to CO2 emission equivalents in the product manufacturing phase",
-            "example": 500.0
+            "example": 200.0
           },
           "materialWaste": {
             "title": "Material Waste [kg]",
             "type": "number",
             "description": "The amount of material waste produced in the product manufacturing phase",
-            "example": 20.0
+            "example": 8.0
           }
         }
       },

--- a/src/draft/Energy/Battery/ChargingHistory.py
+++ b/src/draft/Energy/Battery/ChargingHistory.py
@@ -10,7 +10,7 @@ class ChargingHistoryRequest(CamelCaseModel):
         ...,
         title="Serial Number",
         description="The serial number of the battery",
-        example="A080721",
+        example="MPP48V-296cde7f",
     )
     start: Optional[datetime] = Field(
         None,

--- a/src/draft/Product/Manufacturing/EnvironmentalFootprint.py
+++ b/src/draft/Product/Manufacturing/EnvironmentalFootprint.py
@@ -3,10 +3,10 @@ from pydantic import Field
 
 
 class EnvironmentalFootprintRequest(CamelCaseModel):
-    product_id: str = Field(
+    serial_number: str = Field(
         ...,
-        title="Product ID",
-        description="The product ID given by the manufacturer",
+        title="Serial Number",
+        description="The serial number given by the manufacturer",
         example="MPP48V-296cde7f",
     )
 

--- a/src/draft/Product/Manufacturing/EnvironmentalFootprint.py
+++ b/src/draft/Product/Manufacturing/EnvironmentalFootprint.py
@@ -16,13 +16,13 @@ class EnvironmentalFootprintResponse(CamelCaseModel):
         ...,
         title="Carbon Equivalent (CO2e) [kg]",
         description="The amount of emissions from all greenhouse gases converted to CO2 emission equivalents in the product manufacturing phase",
-        example=500.0,
+        example=200.0,
     )
     material_waste: float = Field(
         ...,
         title="Material Waste [kg]",
         description="The amount of material waste produced in the product manufacturing phase",
-        example=20.0,
+        example=8.0,
     )
 
 


### PR DESCRIPTION
- Use serial number in the environmental footprint as well. 
- Update the example serial number for the charging history