### PR TITLE
Minor fixes to source files for recently added definitions

### DIFF
--- a/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
+++ b/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
@@ -9,7 +9,8 @@ class ManufacturingLocation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the battery manufacturing location in Alpha-3 format",
+        description="The country code of the battery manufacturing location in Alpha-3 "
+        "format",
         examples=["GER"],
     )
     city: Optional[str] = Field(
@@ -54,7 +55,8 @@ class ManufacturerInformation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the manufacturer's headquarters location in Alpha-3 format",
+        description="The country code of the manufacturer's headquarters location in "
+        "Alpha-3 format",
         examples=["USA"],
     )
     website: Optional[str] = Field(
@@ -77,13 +79,17 @@ class CarbonFootprint(CamelCaseModel):
     pre_production_footprint: Optional[float] = Field(
         None,
         title="Pre Production Footprint",
-        description="The carbon footprint of the raw material acquisition and pre-processing phase of the battery calculated as kilograms (kg) of CO2e per one kilowatt-hour (kWh) using preferably PEF and PEFCR methods",
+        description="The carbon footprint of the raw material acquisition and "
+        "pre-processing phase of the battery calculated as kilograms (kg) of CO2e per "
+        "one kilowatt-hour (kWh) using preferably PEF and PEFCR methods",
         examples=[2345.7],
     )
     main_production_footprint: Optional[float] = Field(
         None,
         title="Main Production Footprint",
-        description="The carbon footprint of the battery main production phase calculated as kilograms (kg) of CO2e per one kilowatt-hour (kWh) using preferably PEF and PEFCR methods",
+        description="The carbon footprint of the battery main production phase "
+        "calculated as kilograms (kg) of CO2e per one kilowatt-hour (kWh) using "
+        "preferably PEF and PEFCR methods",
         examples=[3504.4],
     )
     reference_material: Optional[str] = Field(
@@ -91,7 +97,8 @@ class CarbonFootprint(CamelCaseModel):
         pattern=r"^https://",
         max_length=2083,
         title="Reference Material",
-        description="The web link giving access to a public version of the study supporting the carbon footprint values",
+        description="The web link giving access to a public version of the study "
+        "supporting the carbon footprint values",
         examples=["https://example.com/CarbonFootprint"],
     )
 
@@ -125,7 +132,8 @@ class CarbonFootprintResponse(CamelCaseModel):
     carbon_footprint: Optional[CarbonFootprint] = Field(
         None,
         title="Carbon Footprint",
-        description="The details of the carbon footprint for the battery production phases",
+        description="The details of the carbon footprint for the battery production "
+        "phases",
     )
 
 
@@ -149,7 +157,8 @@ class CarbonFootprintRequest(CamelCaseModel):
 DEFINITION = DataProductDefinition(
     version="0.1.0",
     title="Battery Carbon Footprint",
-    description="Carbon footprint of a battery as required by the European Commission's Battery Act (2023/1542)",
+    description="Carbon footprint of a battery as required by the European "
+    "Commission's Battery Act (2023/1542)",
     request=CarbonFootprintRequest,
     response=CarbonFootprintResponse,
 )

--- a/src/DigitalProductPassport/Battery/HealthData_v0.1.py
+++ b/src/DigitalProductPassport/Battery/HealthData_v0.1.py
@@ -37,13 +37,15 @@ class OriginalPerformance(CamelCaseModel):
         None,
         title="Cycle Life",
         ge=0,
-        description="The expected cycle life of the battery that exceed 80% of the capacity under the reference conditions for which it has been designed",
+        description="The expected cycle life of the battery that exceed 80% of the "
+        "capacity under the reference conditions for which it has been designed",
         examples=[5000.0],
     )
     years: Optional[int] = Field(
         None,
         title="Years",
-        description="The expected lifetime of the battery in years under the reference conditions for which it has been designed",
+        description="The expected lifetime of the battery in years under the reference "
+        "conditions for which it has been designed",
         examples=[10],
     )
 
@@ -79,19 +81,22 @@ class HealthState(CamelCaseModel):
     capacity_fade: Optional[float] = Field(
         None,
         title="Capacity Fade",
-        description="The capacity fade of the battery compared to the original capacity in percentage (%)",
+        description="The capacity fade of the battery compared to the original "
+        "capacity in percentage (%)",
         examples=[20.0],
     )
     power_fade: Optional[float] = Field(
         None,
         title="Power Fade",
-        description="The power fade of the battery compared to the original power in percentage (%)",
+        description="The power fade of the battery compared to the original power in "
+        "percentage (%)",
         examples=[15.0],
     )
     resistance_increase: Optional[float] = Field(
         None,
         title="Resistance Increase",
-        description="The value of resistance increase since the battery was first commissioned in percentage (%)",
+        description="The value of resistance increase since the battery was first "
+        "commissioned in percentage (%)",
         examples=[10.0],
     )
     operation_details: List[OperationDetail] = Field(
@@ -112,7 +117,8 @@ class HarmfulEvent(CamelCaseModel):
         None,
         title="Event Description",
         max_length=250,
-        description="The description of the harmful incident that has happened to the battery",
+        description="The description of the harmful incident that has happened to the "
+        "battery",
         examples=["30 minutes spent in extreme temperature -50 celsius"],
     )
 
@@ -151,7 +157,8 @@ class HealthDataResponse(CamelCaseModel):
     harmful_events: List[HarmfulEvent] = Field(
         ...,
         title="Harmful Events",
-        description="The harmful events or incidents that have occurred for the battery",
+        description="The harmful events or incidents that have occurred for the "
+        "battery",
     )
 
 
@@ -175,7 +182,8 @@ class HealthDataRequest(CamelCaseModel):
 DEFINITION = DataProductDefinition(
     version="0.1.0",
     title="Battery Health Data",
-    description="The health and status data of a battery as required by Battery Passport specification of the European Commission's Battery Act (2023/1542)",
+    description="The health and status data of a battery as required by Battery "
+    "Passport specification of the European Commission's Battery Act (2023/1542)",
     request=HealthDataRequest,
     response=HealthDataResponse,
 )

--- a/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
@@ -10,7 +10,8 @@ class ManufacturingLocation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the battery manufacturing location in Alpha-3 format",
+        description="The country code of the battery manufacturing location in Alpha-3 "
+        "format",
         examples=["GER"],
     )
     city: Optional[str] = Field(
@@ -55,7 +56,8 @@ class ManufacturerInformation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the manufacturer's headquarters location in Alpha-3 format",
+        description="The country code of the manufacturer's headquarters location in "
+        "Alpha-3 format",
         examples=["USA"],
     )
     website: Optional[str] = Field(
@@ -85,13 +87,15 @@ class RoundTripEfficiency(CamelCaseModel):
     initial_energy_efficiency: Optional[float] = Field(
         None,
         title="Initial Energy Efficiency",
-        description="The initial round trip energy efficiency of a battery in percentage (%)",
+        description="The initial round trip energy efficiency of a battery in "
+        "percentage (%)",
         examples=[75.0],
     )
     degraded_energy_efficiency: Optional[float] = Field(
         None,
         title="Degraded Energy Efficiency",
-        description="The round trip energy efficiency of an energy storage battery in percentage (%) at 50% of expected cycle life",
+        description="The round trip energy efficiency of an energy storage battery in "
+        "percentage (%) at 50% of expected cycle life",
         examples=[60.0],
     )
 
@@ -121,7 +125,8 @@ class TemperatureRange(CamelCaseModel):
     minimum_temperature: Optional[float] = Field(
         None,
         title="Minimum Temperature",
-        description="The minimum environment temperature the battery can withstand in Celsius degrees",
+        description="The minimum environment temperature the battery can withstand in "
+        "Celsius degrees",
         examples=[-40.0],
         le=100,
         ge=-100,
@@ -129,7 +134,8 @@ class TemperatureRange(CamelCaseModel):
     maximum_temperature: Optional[float] = Field(
         None,
         title="Maximum Temperature",
-        description="The maximum environment temperature the battery can withstand in Celsius degrees",
+        description="The maximum environment temperature the battery can withstand in "
+        "Celsius degrees",
         examples=[50.0],
         le=100,
         ge=-100,
@@ -141,14 +147,16 @@ class ExpectedLifetime(CamelCaseModel):
         None,
         title="Cycle Life",
         ge=0,
-        description="Minimum number of cycles the battery can be recharged to at least 80% of initial capacity",
+        description="Minimum number of cycles the battery can be recharged to at least "
+        "80% of initial capacity",
         examples=[5000],
     )
     reference_test: Optional[str] = Field(
         None,
         title="Reference Test",
         max_length=250,
-        description="The details of the reference test used for defining the expected lifetime",
+        description="The details of the reference test used for defining the expected "
+        "lifetime",
         examples=["Accelerated cycle life testing"],
     )
     cycle_rate: Optional[str] = Field(
@@ -175,7 +183,8 @@ class MaterialComposition(CamelCaseModel):
     critical_raw_materials: List[str] = Field(
         ...,
         title="Critical Raw Materials",
-        description="The critical raw materials present in the battery in a concentration of more than 0.1% weight by weight",
+        description="The critical raw materials present in the battery in a "
+        "concentration of more than 0.1% weight by weight",
         examples=[["Cobalt"]],
     )
 
@@ -191,7 +200,8 @@ class RecycledContent(CamelCaseModel):
     recycling_rate: Optional[float] = Field(
         None,
         title="Recycling Rate",
-        description="The amount of recycled content in the substance in percentage (%) by weight",
+        description="The amount of recycled content in the substance in percentage (%) "
+        "by weight",
         examples=[8.5],
     )
 
@@ -207,7 +217,8 @@ class RenewableContent(CamelCaseModel):
     proportion: Optional[float] = Field(
         None,
         title="Proportion",
-        description="The share of the renewable content present in the battery in percentage (%) by weight",
+        description="The share of the renewable content present in the battery in "
+        "percentage (%) by weight",
         examples=[2.0],
     )
 
@@ -216,13 +227,15 @@ class LegalConformity(CamelCaseModel):
     battery_act_compliance: Optional[bool] = Field(
         None,
         title="Battery Act Compliance",
-        description="The indicator if the battery complies with the requirements of the battery act or not",
+        description="The indicator if the battery complies with the requirements of "
+        "the battery act or not",
         examples=[True],
     )
     requirement_conformity: List[str] = Field(
         ...,
         title="Requirement Conformity",
-        description="The compliance of the battery with other legal and standard requirements",
+        description="The compliance of the battery with other legal and standard "
+        "requirements",
         examples=[["ROHS", "CE HSE", "IEC62619"]],
     )
     conformity_declaration: Optional[str] = Field(
@@ -281,7 +294,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     capacity: Optional[float] = Field(
         None,
         title="Capacity",
-        description="The total number of ampere-hours (Ah) that can be withdrawn from a fully charged battery under reference conditions",
+        description="The total number of ampere-hours (Ah) that can be withdrawn from "
+        "a fully charged battery under reference conditions",
         examples=[100.0],
     )
     power: Optional[float] = Field(
@@ -306,7 +320,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     round_trip_efficiency: Optional[RoundTripEfficiency] = Field(
         None,
         title="Round Trip Efficiency",
-        description="The details of the round trip energy efficiency in energy storages",
+        description="The details of the round trip energy efficiency in energy "
+        "storages",
     )
     voltage_levels: Optional[VoltageLevels] = Field(
         None,
@@ -316,7 +331,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     temperature_range: Optional[TemperatureRange] = Field(
         None,
         title="Temperature Range",
-        description="The details of the acceptable environment temperature values for the battery",
+        description="The details of the acceptable environment temperature values for "
+        "the battery",
     )
     expected_lifetime: Optional[ExpectedLifetime] = Field(
         None,
@@ -341,13 +357,15 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     extinguishing_agents: List[str] = Field(
         ...,
         title="Extinguishing Agents",
-        description="The type of the fire extinguishing agents that can be used for the battery",
+        description="The type of the fire extinguishing agents that can be used for "
+        "the battery",
         examples=[["foam", "carbon dioxide"]],
     )
     legal_conformity: Optional[LegalConformity] = Field(
         None,
         title="Legal Conformity",
-        description="The details of the conformity of the battery with the legal and harmonized standards",
+        description="The details of the conformity of the battery with the legal and "
+        "harmonized standards",
     )
     warranty: Optional[str] = Field(
         None,
@@ -378,7 +396,8 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
 DEFINITION = DataProductDefinition(
     version="0.1.0",
     title="Battery Manufacturing Data Sheet",
-    description="Manufacturing data sheet as required by Battery Passport specification of the European Commission's Battery Act (2023/1542)",
+    description="Manufacturing data sheet as required by Battery Passport "
+    "specification of the European Commission's Battery Act (2023/1542)",
     request=ManufacturingDataSheetRequest,
     response=ManufacturingDataSheetResponse,
 )

--- a/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/Drill/ManufacturingDataSheet_v0.1.py
@@ -37,7 +37,8 @@ class ManufacturerInformation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the manufacturer's headquarters location in Alpha-3 format",
+        description="The country code of the manufacturer's headquarters location in "
+        "Alpha-3 format",
         examples=["SWE"],
     )
     website: Optional[str] = Field(
@@ -72,13 +73,15 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     boom_coverage: Optional[float] = Field(
         None,
         title="Boom Coverage",
-        description="The largest distance to which the drill boom can reach from the machine in meters (m)",
+        description="The largest distance to which the drill boom can reach from the "
+        "machine in meters (m)",
         examples=[3.0],
     )
     tramming_distance: Optional[float] = Field(
         None,
         title="Tramming Distance",
-        description="The maximum tramming distance of the drill movement in kilometers (km)",
+        description="The maximum tramming distance of the drill movement in kilometers "
+        "(km)",
         examples=[3.0],
     )
     maximum_hole_length: Optional[float] = Field(
@@ -90,13 +93,15 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
     minimum_hole_diameter: Optional[float] = Field(
         None,
         title="Minimum Hole Diameter",
-        description="The minimum diameter measure of the drilling hole in millimeters (mm)",
+        description="The minimum diameter measure of the drilling hole in millimeters "
+        "(mm)",
         examples=[76.0],
     )
     maximum_hole_diameter: Optional[float] = Field(
         None,
         title="Maximum Hole Diameter",
-        description="The maximum diameter measure of the drilling hole in millimeters (mm)",
+        description="The maximum diameter measure of the drilling hole in millimeters "
+        "(mm)",
         examples=[127.0],
     )
     drilling_power: Optional[float] = Field(

--- a/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
@@ -8,13 +8,15 @@ class CarbonFootprint(CamelCaseModel):
     pre_production_footprint: Optional[float] = Field(
         None,
         title="Pre Production Footprint",
-        description="The carbon footprint of the pre-manufacture phase of the machine calculated as kg of CO2e per one kWh using preferably PEF and PEFCR methods",
+        description="The carbon footprint of the pre-manufacture phase of the machine "
+        "calculated as kg of CO2e per one kWh using preferably PEF and PEFCR methods",
         examples=[2345.7],
     )
     main_production_footprint: Optional[float] = Field(
         None,
         title="Main Production Footprint",
-        description="The carbon footprint of the machine main production phase calculated as kg of CO2e per one kWh using preferably PEF and PEFCR methods",
+        description="The carbon footprint of the machine main production phase "
+        "calculated as kg of CO2e per one kWh using preferably PEF and PEFCR methods",
         examples=[3504.4],
     )
     reference_material: Optional[str] = Field(
@@ -22,7 +24,8 @@ class CarbonFootprint(CamelCaseModel):
         pattern=r"^https://",
         max_length=2083,
         title="Reference Material",
-        description="The link giving access to a public version of the study supporting the carbon footprint values",
+        description="The link giving access to a public version of the study "
+        "supporting the carbon footprint values",
         examples=["https://example.com/CarbonFootprint"],
     )
 
@@ -31,7 +34,8 @@ class MaterialWaste(CamelCaseModel):
     amount: Optional[float] = Field(
         None,
         title="Amount",
-        description="The amount of material waste in kilograms (kg) generated during the machine production",
+        description="The amount of material waste in kilograms (kg) generated during "
+        "the machine production",
         examples=[500.0],
     )
     reference_material: Optional[str] = Field(
@@ -39,7 +43,8 @@ class MaterialWaste(CamelCaseModel):
         pattern=r"^https://",
         max_length=2083,
         title="Reference Material",
-        description="The link giving access to a public version of the study supporting the material waste values",
+        description="The link giving access to a public version of the study "
+        "supporting the material waste values",
         examples=["https://example.com/CarbonFootprint"],
     )
 
@@ -48,7 +53,8 @@ class DataSheetResponse(CamelCaseModel):
     carbon_footprint: CarbonFootprint = Field(
         ...,
         title="Carbon Footprint",
-        description="The details of the carbon footprint for the machine production phases",
+        description="The details of the carbon footprint for the machine production "
+        "phases",
     )
     material_waste: Optional[MaterialWaste] = Field(
         None,

--- a/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
+++ b/src/DigitalProductPassport/MobileWorkMachine/EnvironmentalFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import Field
 
 
 class CarbonFootprint(CamelCaseModel):


### PR DESCRIPTION
This removes one unused import and ensures lines are not longer than 88 chars. As can be seen this only touches the `.py` source files, the final OpenAPI spec files do not change, hence no update of the version number in them either.