### PR TITLE
Update example in battery health data to be an integer

### DIFF
--- a/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery Health Data",
     "description": "The health and status data of a battery as required by Battery Passport specification of the European Commission's Battery Act (2023/1542)",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/DigitalProductPassport/Battery/HealthData_v0.1": {
@@ -602,7 +602,7 @@
             ],
             "title": "Cycle Life",
             "description": "The expected cycle life of the battery that exceed 80% of the capacity under the reference conditions for which it has been designed",
-            "examples": [5000.0]
+            "examples": [5000]
           },
           "years": {
             "anyOf": [

--- a/src/DigitalProductPassport/Battery/HealthData_v0.1.py
+++ b/src/DigitalProductPassport/Battery/HealthData_v0.1.py
@@ -39,7 +39,7 @@ class OriginalPerformance(CamelCaseModel):
         ge=0,
         description="The expected cycle life of the battery that exceed 80% of the "
         "capacity under the reference conditions for which it has been designed",
-        examples=[5000.0],
+        examples=[5000],
     )
     years: Optional[int] = Field(
         None,
@@ -180,7 +180,7 @@ class HealthDataRequest(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Battery Health Data",
     description="The health and status data of a battery as required by Battery "
     "Passport specification of the European Commission's Battery Act (2023/1542)",


### PR DESCRIPTION
The example value was accidentally created as a float despite the field expecting an integer. This will not affect data passing through by any means, so bumped just the PATCH version.