### PR TITLE
Fix typos in definition examples

### DIFF
--- a/DataProducts/DigitalProductPassport/Battery/CarbonFootprint_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery Carbon Footprint",
     "description": "Carbon footprint of a battery as required by the European Commission's Battery Act (2023/1542)",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/DigitalProductPassport/Battery/CarbonFootprint_v0.1": {
@@ -541,7 +541,7 @@
             ],
             "title": "Country",
             "description": "The country code of the battery manufacturing location in Alpha-3 format",
-            "examples": ["GER"]
+            "examples": ["DEU"]
           },
           "city": {
             "anyOf": [

--- a/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/HealthData_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery Health Data",
     "description": "The health and status data of a battery as required by Battery Passport specification of the European Commission's Battery Act (2023/1542)",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/DigitalProductPassport/Battery/HealthData_v0.1": {
@@ -311,7 +311,7 @@
             ],
             "title": "Event Description",
             "description": "The description of the harmful incident that has happened to the battery",
-            "examples": ["30 minutes spent in extreme temperature -50 celsius"]
+            "examples": ["30 minutes spent in extreme temperature -50 Celsius"]
           }
         },
         "type": "object",

--- a/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery Manufacturing Data Sheet",
     "description": "Manufacturing data sheet as required by Battery Passport specification of the European Commission's Battery Act (2023/1542)",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1": {
@@ -786,7 +786,7 @@
             ],
             "title": "Country",
             "description": "The country code of the battery manufacturing location in Alpha-3 format",
-            "examples": ["GER"]
+            "examples": ["DEU"]
           },
           "city": {
             "anyOf": [

--- a/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
+++ b/src/DigitalProductPassport/Battery/CarbonFootprint_v0.1.py
@@ -11,7 +11,7 @@ class ManufacturingLocation(CamelCaseModel):
         pattern=r"^[A-Z]{3}$",
         description="The country code of the battery manufacturing location in Alpha-3 "
         "format",
-        examples=["GER"],
+        examples=["DEU"],
     )
     city: Optional[str] = Field(
         None,
@@ -155,7 +155,7 @@ class CarbonFootprintRequest(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Battery Carbon Footprint",
     description="Carbon footprint of a battery as required by the European "
     "Commission's Battery Act (2023/1542)",

--- a/src/DigitalProductPassport/Battery/HealthData_v0.1.py
+++ b/src/DigitalProductPassport/Battery/HealthData_v0.1.py
@@ -119,7 +119,7 @@ class HarmfulEvent(CamelCaseModel):
         max_length=250,
         description="The description of the harmful incident that has happened to the "
         "battery",
-        examples=["30 minutes spent in extreme temperature -50 celsius"],
+        examples=["30 minutes spent in extreme temperature -50 Celsius"],
     )
 
 
@@ -180,7 +180,7 @@ class HealthDataRequest(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     title="Battery Health Data",
     description="The health and status data of a battery as required by Battery "
     "Passport specification of the European Commission's Battery Act (2023/1542)",

--- a/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
@@ -12,7 +12,7 @@ class ManufacturingLocation(CamelCaseModel):
         pattern=r"^[A-Z]{3}$",
         description="The country code of the battery manufacturing location in Alpha-3 "
         "format",
-        examples=["GER"],
+        examples=["DEU"],
     )
     city: Optional[str] = Field(
         None,
@@ -394,7 +394,7 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     title="Battery Manufacturing Data Sheet",
     description="Manufacturing data sheet as required by Battery Passport "
     "specification of the European Commission's Battery Act (2023/1542)",


### PR DESCRIPTION
- Fix incorrect country code
- Fix incorrect spelling of Celsius