### PR TITLE
Fix to DigitalProductPassport/Textile/Garment/BillOfMaterials

### DIFF
--- a/DataProducts/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Garment Bill of Materials",
     "description": "Details of the garment's bill of materials.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1": {
@@ -252,9 +252,7 @@
           "colorScheme": {
             "anyOf": [
               {
-                "$ref": "#/components/schemas/ColorScheme",
-                "maxLength": 10,
-                "minLength": 0
+                "$ref": "#/components/schemas/ColorScheme"
               },
               {
                 "type": "null"

--- a/src/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.py
+++ b/src/DigitalProductPassport/Textile/Garment/BillOfMaterials_v0.1.py
@@ -27,8 +27,6 @@ class ColorInformation(CamelCaseModel):
         None,
         title="Color scheme",
         description="The scheme indicating the garment color.",
-        min_length=0,
-        max_length=10,
         examples=[ColorScheme.PANTONE],
     )
     color: Optional[str] = Field(
@@ -155,7 +153,7 @@ class Response(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Garment Bill of Materials",
     description="Details of the garment's bill of materials.",
     tags=["Manufacturing"],


### PR DESCRIPTION
An enum field accidentally had min/max length defined. Should not affect data that is allowed through (might accidentally have caused one of the enum values unintentionally to be disallowed).